### PR TITLE
Removed insecure SSL configuration.

### DIFF
--- a/application/helpers/account/php-openid-php5.3/Auth/Yadis/ParanoidHTTPFetcher.php
+++ b/application/helpers/account/php-openid-php5.3/Auth/Yadis/ParanoidHTTPFetcher.php
@@ -127,8 +127,7 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
                         Auth_OpenID_USER_AGENT.' '.$curl_user_agent);
             curl_setopt($c, CURLOPT_TIMEOUT, $off);
             curl_setopt($c, CURLOPT_URL, $url);
-			curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
-
+		
             curl_exec($c);
 
             $code = curl_getinfo($c, CURLINFO_HTTP_CODE);
@@ -191,8 +190,7 @@ class Auth_Yadis_ParanoidHTTPFetcher extends Auth_Yadis_HTTPFetcher {
         curl_setopt($c, CURLOPT_URL, $url);
         curl_setopt($c, CURLOPT_WRITEFUNCTION,
                     array(&$this, "_writeData"));
-		curl_setopt($c, CURLOPT_SSL_VERIFYPEER, false);
-
+	
         curl_exec($c);
 
         $code = curl_getinfo($c, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
As it was, the openID auth was vulnurable to MITM attacks. Unfortunately it is a common practice to NOT verify the host in curl, due to an old curl version that had outdated certificates. If anyone is still working on an out-dated curl version he should check out http://stackoverflow.com/questions/316099/cant-connect-to-https-site-using-curl-returns-0-length-content-instead-what-c for a secure fix.
