### PR TITLE
Moving the notice about disabled registration into language file

### DIFF
--- a/application/language/english/account/sign_up_lang.php
+++ b/application/language/english/account/sign_up_lang.php
@@ -23,6 +23,8 @@ $lang['sign_up_username_taken'] = 'This Username is already taken.';
 $lang['sign_up_email_exist'] = 'This Email is already registered.';
 $lang['sign_up_forgot_your_password'] = 'Forgot your password?';
 
+$lang['sign_up_notice'] = 'NOTICE:';
+$lang['sign_up_registration_disabled'] = 'New account registrations are currently disabled.';
 
 /* End of file sign_up_lang.php */
 /* Location: ./application/account/language/english/sign_up_lang.php */

--- a/application/views/sign_up.php
+++ b/application/views/sign_up.php
@@ -16,7 +16,7 @@
 				<h3><?php echo lang('sign_up_heading'); ?></h3>
 
 				<div class="alert">
-					<strong>NOTICE: </strong> New account registrations are currently disabled.
+					<strong><?php echo lang('sign_up_notice'); ?> </strong> <?php echo lang('sign_up_registration_disabled'); ?>
 				</div>
 			</div>
 		<?php endif;?>


### PR DESCRIPTION
The notice about disabled registration was not in a language file as all the other text. Not anymore.
