### PR TITLE
"Cache" account_permissions on same request

### DIFF
--- a/application/libraries/account/Authorization.php
+++ b/application/libraries/account/Authorization.php
@@ -21,6 +21,8 @@ class Authorization
    * @var object
    */
   var $CI;
+  
+  private $_account_permissions_cache = array();
 
   /**
    * Constructor
@@ -57,7 +59,15 @@ class Authorization
 
     $this->CI->load->model('account/Acl_permission_model');
 
-    $account_permissions = $this->CI->Acl_permission_model->get_by_account_id($account_id);
+    if (isset($this->_account_permissions_cache[$account_id]))
+    {
+        $account_permissions = $this->_account_permissions_cache[$account_id];
+    }
+    else
+    {
+        $account_permissions = $this->CI->Acl_permission_model->get_by_account_id($account_id);
+        $this->_account_permissions_cache[$account_id] = $account_permissions;
+    }
 
     // Loop through and check if the account 
     // has any of the permission keys supplied


### PR DESCRIPTION
Creating a variable to hold account_permissions to avoid hitting database every call to is_permitted.
On the first call, populates this variable with values from database. Next calls will get values from this variable.